### PR TITLE
replace_with_comment does not create trailing whitespace

### DIFF
--- a/lib/Pod/Elemental/PerlMunger.pm
+++ b/lib/Pod/Elemental/PerlMunger.pm
@@ -212,7 +212,8 @@ sub replace_with_comment {
 
   my $text = "$element";
 
-  (my $pod = $text) =~ s/^/# /mg;
+  (my $pod = $text) =~ s/^(.)/# $1/mg;
+  $pod =~ s/^$/#/mg;
   my $commented_out = PPI::Token::Comment->new($pod);
 
   return $commented_out;


### PR DESCRIPTION
There don't seem to be any tests for this function, but it works...

I'd test with something like this:
`
my $content = $file->slurp;
unlike($content, qr/[^\S\n]\n/m, 'no trailing whitespace in munged code');`
