### PR TITLE
make replace_with_comment use comments that are later extractable with a regex

### DIFF
--- a/lib/Pod/Elemental/PerlMunger.pm
+++ b/lib/Pod/Elemental/PerlMunger.pm
@@ -250,8 +250,8 @@ sub replace_with_comment {
 
   my $text = "$element";
 
-  (my $pod = $text) =~ s/^(.)/# $1/mg;
-  $pod =~ s/^$/#/mg;
+  (my $pod = $text) =~ s/^(.)/#pod $1/mg;
+  $pod =~ s/^$/#pod/mg;
   my $commented_out = PPI::Token::Comment->new($pod);
 
   return $commented_out;

--- a/t/corpus/mid-code-comm.out.txt
+++ b/t/corpus/mid-code-comm.out.txt
@@ -1,11 +1,11 @@
 
 my $x = 1;
 
-# =head1 Foo
-#
-# This is mid-code!
-#
-# =cut
+#pod =head1 Foo
+#pod
+#pod This is mid-code!
+#pod
+#pod =cut
 
 my $y = 2;
 

--- a/t/corpus/straddle-code-comm-nothing.out.txt
+++ b/t/corpus/straddle-code-comm-nothing.out.txt
@@ -1,11 +1,11 @@
 
 my $x = 1;
 
-# =head1 Foo
-#
-# This is mid-code!
-#
-# =cut
+#pod =head1 Foo
+#pod
+#pod This is mid-code!
+#pod
+#pod =cut
 
 my $y = 2;
 

--- a/t/corpus/straddle-code-comm.out.txt
+++ b/t/corpus/straddle-code-comm.out.txt
@@ -1,19 +1,19 @@
 
 my $x = 1;
 
-# =head1 Foo
-#
-# This is mid-code!
-#
-# =cut
+#pod =head1 Foo
+#pod
+#pod This is mid-code!
+#pod
+#pod =cut
 
 my $y = 2;
 
-# =head1 Bar
-#
-# This is post-code!
-#
-# =cut
+#pod =head1 Bar
+#pod
+#pod This is post-code!
+#pod
+#pod =cut
 
 __END__
 


### PR DESCRIPTION
This makes it easier to see which comments were added by the munger, and which belonged there all along - for those who want to undzilify (say for performing diffs).
