### PR TITLE
Patrick cronin/add breaking test

### DIFF
--- a/t/corpus/breaking-map.in.txt
+++ b/t/corpus/breaking-map.in.txt
@@ -1,0 +1,10 @@
+# Breaks Pod::Weaver:
+# return [ map { $i++ / 2 } (1..5) ];
+
+# Does not break Pod::Weaver:
+# return [ map { $i++ } (1..5) ];
+# return [ map { $i / 2 } (1..5) ];
+
+return [ map { $i++ / 2 } (1..5) ];
+
+=head1 HI MOM!

--- a/t/corpus/breaking-map.in.txt
+++ b/t/corpus/breaking-map.in.txt
@@ -1,7 +1,7 @@
-# Breaks Pod::Weaver:
+# Breaks POD extraction:
 # return [ map { $i++ / 2 } (1..5) ];
 
-# Does not break Pod::Weaver:
+# Does not break POD extraction:
 # return [ map { $i++ } (1..5) ];
 # return [ map { $i / 2 } (1..5) ];
 

--- a/t/corpus/breaking-map.out.txt
+++ b/t/corpus/breaking-map.out.txt
@@ -1,7 +1,7 @@
-# Breaks Pod::Weaver:
+# Breaks POD extraction:
 # return [ map { $i++ / 2 } (1..5) ];
 
-# Does not break Pod::Weaver:
+# Does not break POD extraction:
 # return [ map { $i++ } (1..5) ];
 # return [ map { $i / 2 } (1..5) ];
 

--- a/t/corpus/breaking-map.out.txt
+++ b/t/corpus/breaking-map.out.txt
@@ -1,0 +1,15 @@
+# Breaks Pod::Weaver:
+# return [ map { $i++ / 2 } (1..5) ];
+
+# Does not break Pod::Weaver:
+# return [ map { $i++ } (1..5) ];
+# return [ map { $i / 2 } (1..5) ];
+
+return [ map { $i++ / 2 } (1..5) ];
+
+__END__
+
+=pod
+
+=head1 HI MOM!
+=cut

--- a/t/perlmunger.t
+++ b/t/perlmunger.t
@@ -58,7 +58,7 @@ test 'DATA section' => "data-section.in.txt", "data-section.out.txt";
 
 test 'pod mid-code' => "mid-code.in.txt", "mid-code.out.txt";
 
-test 'offensive map' => "breaking-map.in.txt", "breaking-map.out.txt";
+test 'breaking map' => "breaking-map.in.txt", "breaking-map.out.txt";
 
 # We test for this separately because prior to Pod::Elemental 0.103, documents
 # would always stringify to add an extra =pod and =cut around the edges, which

--- a/t/perlmunger.t
+++ b/t/perlmunger.t
@@ -58,6 +58,8 @@ test 'DATA section' => "data-section.in.txt", "data-section.out.txt";
 
 test 'pod mid-code' => "mid-code.in.txt", "mid-code.out.txt";
 
+test 'offensive map' => "breaking-map.in.txt", "breaking-map.out.txt";
+
 # We test for this separately because prior to Pod::Elemental 0.103, documents
 # would always stringify to add an extra =pod and =cut around the edges, which
 # was gross.  This test identified the bug, now fixed i Pod::Elemental.


### PR DESCRIPTION
I've found a line of source that prevents correct POD extraction from source.

`return [ map { $i++ / 2 } (1..5) ];` prevents the extraction of POD after it, while
`return [ map { $i++ } (1..5) ];` is fine and
`return [ map { $i / 2 } (1..5) ];`is fine as well.

This PR adds a breaking test case that demonstrates the failure.